### PR TITLE
S3 Storage implements `.size()` and `.url()` of Django expected interface

### DIFF
--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -67,7 +67,7 @@ def _strip_prefix(text, prefix):
 
 def _strip_s3_path(path):
     assert path.startswith('s3://')
-    bucket, _, path = path.replace('s3://', '').partition('/')
+    bucket, _, path = _strip_prefix(path, 's3://').partition('/')
     return bucket, path
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -38,16 +38,19 @@ MINIO_S3_SETTINGS = {
 }
 
 
-@pytest.mark.parametrize("storage_class, storage_params", [
-    (storages.TemporaryFilesystemStorage, {}),
-    (storages.S3Storage, {
-        'settings': MINIO_S3_SETTINGS,
-        'workdir': f's3://nondjango-storages-test/storage-test-{uuid.uuid4()}/'
-    }),
-])
-def test_file_read_write(storage_class, storage_params):
+@pytest.fixture(scope="module",
+                params=[(storages.TemporaryFilesystemStorage, {}),
+                        (storages.S3Storage, {
+                            'settings': MINIO_S3_SETTINGS,
+                            'workdir': f's3://nondjango-storages-test/storage-test-{uuid.uuid4()}/'
+                        })])
+def storage(request):
+    storage_class, init_params = request.param
+    yield storage_class(**init_params)
+
+
+def test_file_read_write(storage):
     payload = 'test payload'
-    storage = storage_class(**storage_params)
     try:
         storage.delete('test_file.txt')
     except NotImplementedError:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -43,7 +43,8 @@ MINIO_S3_SETTINGS = {
                         (storages.S3Storage, {
                             'settings': MINIO_S3_SETTINGS,
                             'workdir': f's3://nondjango-storages-test/storage-test-{uuid.uuid4()}/'
-                        })])
+                        })],
+                ids=lambda x: x[0])
 def storage(request):
     storage_class, init_params = request.param
     yield storage_class(**init_params)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -12,22 +12,6 @@ logging.getLogger('boto3').setLevel(logging.ERROR)
 logging.getLogger('botocore').setLevel(logging.ERROR)
 logging.getLogger('s3transfer').setLevel(logging.ERROR)
 
-
-def test_prepare_empty_path():
-    utils.prepare_path('')
-
-
-def test_filesystem_storages_honor_workdir():
-    storage = storages.TemporaryFilesystemStorage()
-    filename = 'test_file.txt'
-    f = storage.open(filename, 'w+')
-    f.write('test payload')
-    f.close()
-
-    workdir = storage._workdir
-    assert filename in os.listdir(workdir), 'File is not on the storage workdir'
-
-
 # From: https://docs.minio.io/docs/aws-cli-with-minio.html
 MINIO_S3_SETTINGS = {
     'AWS_ACCESS_KEY_ID': 'Q3AM3UQ867SPQQA43P2F',
@@ -48,6 +32,21 @@ MINIO_S3_SETTINGS = {
 def storage(request):
     storage_class, init_params = request.param
     yield storage_class(**init_params)
+
+
+def test_prepare_empty_path():
+    utils.prepare_path('')
+
+
+def test_filesystem_storages_honor_workdir():
+    storage = storages.TemporaryFilesystemStorage()
+    filename = 'test_file.txt'
+    f = storage.open(filename, 'w+')
+    f.write('test payload')
+    f.close()
+
+    workdir = storage._workdir
+    assert filename in os.listdir(workdir), 'File is not on the storage workdir'
 
 
 def test_file_read_write(storage):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -68,6 +68,13 @@ def test_file_read_write(storage):
         assert f2.read() == payload
 
 
+def test_file_size(storage):
+    payload = '123456789'
+    with storage.open('test_file.txt', 'w+') as f:
+        f.write(payload)
+    assert storage.size('test_file.txt') == len(payload), 'Wrong size returned?'
+
+
 def test_file_url():
     storage = storages.S3Storage(settings=MINIO_S3_SETTINGS,
                                  workdir=f's3://nondjango-storages-test/storage-test-{uuid.uuid4()}/')


### PR DESCRIPTION
There two methods are not needed before but will be used for now on.

Also, get_valid_name() returns a name valid inside the bucket, instead of a full URI. Such behavior is more correct given the Django Storages spec. However it lightly breaks compatibility with current released version of nondjango-storages.