### PR TITLE
S3Storage.url() by default generates the URL even for inexistent files

### DIFF
--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -320,21 +320,23 @@ class S3Storage(BaseStorage):
         else:
             return s3_file.e_tag
 
-    def url(self, name: str):
+    def url(self, name: str, check_for_inexistent=False):
         """
         Returns the URL where the contents of the file referenced by name can be accessed.
         This can raise NotImplementedError depending on the backend used.
         """
         internal_name = self.get_valid_name(name)
         s3_file = self.s3.Object(self._bucket_name, self._normalize_name(internal_name))
-        try:
-            # See if the resource exists
-            s3_file.e_tag
-        except ClientError as err:
-            err_msg = str(err)
-            if '404' in err_msg and 'Not Found' in err_msg:
-                return None
-            raise
+
+        if check_for_inexistent:
+            try:
+                # See if the resource exists
+                s3_file.e_tag
+            except ClientError as err:
+                err_msg = str(err)
+                if '404' in err_msg and 'Not Found' in err_msg:
+                    return None
+                raise
 
         url = self.s3.meta.client.generate_presigned_url(
             'get_object',

--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -320,7 +320,7 @@ class S3Storage(BaseStorage):
         else:
             return s3_file.e_tag
 
-    def url(self, name: str, check_for_inexistent=False):
+    def url(self, name: str, check_for_inexistent=True) -> str:
         """
         Returns the URL where the contents of the file referenced by name can be accessed.
         This can raise NotImplementedError depending on the backend used.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -95,8 +95,8 @@ def test_file_url():
     with storage.open('test_file.txt', 'w+') as f:
         f.write(payload)
 
-    assert storage.url('inexistent_file'), 'Checking before producing the URL?'
-    assert storage.url('inexistant_file', check_for_inexistent=True) is None, 'Generating URLs for inexistent files?'
+    assert storage.url('inexistent_file', check_for_inexistent=False), 'Checking before producing the URL?'
+    assert storage.url('inexistant_file') is None, 'Generating URLs for inexistent files?'
 
     test_file_url = storage.url('test_file.txt')
     assert test_file_url.startswith('https://play.min.io:9000/nondjango-storages-test/storage-test-')

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -95,7 +95,8 @@ def test_file_url():
     with storage.open('test_file.txt', 'w+') as f:
         f.write(payload)
 
-    assert storage.url('inexistant_file') is None, 'Generating URLs for inexistent files?'
+    assert storage.url('inexistent_file'), 'Checking before producing the URL?'
+    assert storage.url('inexistant_file', check_for_inexistent=True) is None, 'Generating URLs for inexistent files?'
 
     test_file_url = storage.url('test_file.txt')
     assert test_file_url.startswith('https://play.min.io:9000/nondjango-storages-test/storage-test-')


### PR DESCRIPTION
This saves one roundtrip to the server.
Use `.url(check_for_inexistent=True)` for the old behavior of returning `None` instead.