### PR TITLE
On S3 storage, use HEAD to check for file existence

### DIFF
--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -352,19 +352,10 @@ class S3Storage(BaseStorage):
         Returns the URL where the contents of the file referenced by name can be accessed.
         This can raise NotImplementedError depending on the backend used.
         """
+        if check_for_inexistent and not self.exists(name):
+            return None
+
         internal_name = self.get_valid_name(name)
-        s3_file = self.s3.Object(self._bucket_name, self._normalize_name(internal_name))
-
-        if check_for_inexistent:
-            try:
-                # See if the resource exists
-                s3_file.e_tag
-            except ClientError as err:
-                err_msg = str(err)
-                if '404' in err_msg and 'Not Found' in err_msg:
-                    return None
-                raise
-
         url = self.s3.meta.client.generate_presigned_url(
             'get_object',
             Params={


### PR DESCRIPTION
Optimizes check for .exists() via HTTP HEAD on S3, instead of doing a full listing and searching for the file name.